### PR TITLE
Update F01_Cano.tex

### DIFF
--- a/abstracts/F01_Cano.tex
+++ b/abstracts/F01_Cano.tex
@@ -50,9 +50,11 @@ nonlinear function at hand. Such parameters, namely: \(C\) and
 \(\epsilon\), can be explicitely assigned in the \emph{smoothProfile()}
 function of the \emph{SixSigma} package. However, a quality control
 practicioner seldom knows about SVMs, needless to say that they have no
-time to spend modelling functions. Hence, we rely on to automatically
-fit the SVM parameters using the process data, thereby achieving
-unattended SVM fitting. Furthermore, noise is previously estimated by
-means of a loess fit.
+time to spend modelling functions. Hence, we rely on Cherkassky, V and 
+Ma, Y (2004)\footnote{Practical selection of SVM parameters and noise
+estimation for SVM regression. Neural Networks, 17(1), 113-126} to 
+automatically fit the SVM parameters using the process data, thereby 
+achieving unattended SVM fitting. Furthermore, noise is previously 
+estimated by means of a loess fit.
 
 \end{document}


### PR DESCRIPTION
In the original abstract there were references, now that they have been removed, a changed is needed in the sentence before the last one. I propose a footnote, but if it is not possible, just remove it (but keep the referenced author)
